### PR TITLE
Possible fix for Issue 2 :

### DIFF
--- a/exec.sh
+++ b/exec.sh
@@ -18,9 +18,9 @@ if [ ! -e ~/CyberClient.conf ] ; then
 	unset CR_IP
 	unset CR_PSSWD
 	unset CR_ID
-	return $RET;
+	exit $RET;
 fi
 
 
 ./crclient -u `cat CR_ID.txt` -i lo > /dev/null
-return $?
+exit $?


### PR DESCRIPTION
'return' statements fail when crconn is ran, since its a sym link to exec.sh, essentially turning the call into : $ /home/.../CyberRoamClientForBITSHyd/exec.sh, where SHLVL is 2.Hence, it is the shell (bash in this case) which makes the final 'return'.

Using 'exit' abandons the current shell, where the sheel in turn returns the value next to the exit statement.

refer http://stackoverflow.com/questions/4419952/difference-between-return-and-exit-in-bash-functions.
